### PR TITLE
Don't ignore last block if it's less than blockLen

### DIFF
--- a/signature.go
+++ b/signature.go
@@ -73,7 +73,7 @@ func Signature(input io.Reader, output io.Writer, blockLen, strongLen uint32, si
 	ret.blockLen = blockLen
 
 	for {
-		n, err := io.ReadFull(input, block)
+		n, err := input.Read(block)
 		if err == io.ErrUnexpectedEOF || err == io.EOF {
 			break
 		} else if err != nil {


### PR DESCRIPTION
If the last remaining block is shorter than blockLen `io.ReadFull` will return `io.ErrUnexpectedEOF` and the block will not be processed (signature will be one block too short).