### PR TITLE
Bugfix: use signed arithmetic in Rollsum.Rotate()

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,11 @@
 module github.com/balena-os/librsync-go
 
+go 1.16
+
 require (
 	github.com/balena-os/circbuf v0.0.0-20171122095043-56e73111d0b2
 	github.com/sirupsen/logrus v1.3.0
+	github.com/stretchr/testify v1.7.0
 	github.com/urfave/cli v1.20.0
 	golang.org/x/crypto v0.0.0-20190122013713-64072686203f
 	golang.org/x/sys v0.0.0-20190122071731-054c452bb702 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 github.com/balena-os/circbuf v0.0.0-20171122095043-56e73111d0b2 h1:ElIDKSaGfOSwGn98Bo0gVVDaUdnjqj4MC9/mFWqTDos=
 github.com/balena-os/circbuf v0.0.0-20171122095043-56e73111d0b2/go.mod h1:Iy/J8+4PzU1eYB67p/3ebi+oM5//WVL7ohT3JikR3Hs=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
@@ -8,9 +9,11 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.3.0 h1:hI/7Q+DtNZ2kINb6qt/lS+IyXnHQe9e90POfeewL/ME=
 github.com/sirupsen/logrus v1.3.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/urfave/cli v1.20.0 h1:fDqGv3UG/4jbVl/QkFwEdddtEDjh/5Ov6X+0B/3bPaw=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -19,3 +22,7 @@ golang.org/x/crypto v0.0.0-20190122013713-64072686203f/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190122071731-054c452bb702 h1:Lk4tbZFnlyPgV+sLgTw5yGfzrlOn9kx4vSombi2FFlY=
 golang.org/x/sys v0.0.0-20190122071731-054c452bb702/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/rollsum.go
+++ b/rollsum.go
@@ -40,7 +40,7 @@ func (r *Rollsum) Update(p []byte) {
 }
 
 func (r *Rollsum) Rotate(out, in byte) {
-	r.s1 += uint16(in - out)
+	r.s1 += uint16(in) - uint16(out)
 	r.s2 += r.s1 - uint16(r.count)*(uint16(out)+uint16(ROLLSUM_CHAR_OFFSET))
 }
 

--- a/rollsum_test.go
+++ b/rollsum_test.go
@@ -1,0 +1,105 @@
+package librsync
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRollsumBrandNew(t *testing.T) {
+	a := assert.New(t)
+	r := Rollsum{}
+
+	a.Equal(uint32(0x00000000), r.Digest())
+}
+
+func TestRollsumRollinRollout(t *testing.T) {
+	a := assert.New(t)
+	r := Rollsum{}
+
+	r.Rollin(222)
+	a.Equal(uint32(0x00FD00FD), r.Digest())
+	r.Rollin(11)
+	a.Equal(uint32(0x02240127), r.Digest())
+	r.Rollin(0)
+	a.Equal(uint32(0x036A0146), r.Digest())
+	r.Rollin(13)
+	a.Equal(uint32(0x04DC0172), r.Digest())
+	r.Rollin(7)
+	a.Equal(uint32(0x06740198), r.Digest())
+
+	r.Rollout(222)
+	a.Equal(uint32(0x0183009B), r.Digest())
+	r.Rollout(11)
+	a.Equal(uint32(0x00DB0071), r.Digest())
+	r.Rollout(0)
+	a.Equal(uint32(0x007E0052), r.Digest())
+
+	r.Rollin(1)
+	a.Equal(uint32(0x00F00072), r.Digest())
+}
+
+func TestRollsumUpdate(t *testing.T) {
+	a := assert.New(t)
+	r := Rollsum{}
+	data := []byte{222, 11, 0, 13, 7}
+	moreData := []byte{66, 171, 8}
+
+	r.Update(data)
+	a.Equal(uint32(0x06740198), r.Digest())
+	r.Update(moreData)
+	a.Equal(uint32(0x0E1A02EA), r.Digest())
+}
+
+func TestRollsumRotate(t *testing.T) {
+	a := assert.New(t)
+	r := Rollsum{}
+	data := []byte{222, 11, 0, 13, 7}
+
+	r.Update(data)
+
+	r.Rotate(222, 39)
+	a.Equal(uint32(0x026400E1), r.Digest())
+	r.Rotate(11, 177)
+	a.Equal(uint32(0x03190187), r.Digest())
+	r.Rotate(0, 0)
+	a.Equal(uint32(0x04050187), r.Digest())
+}
+
+// Sanity check to verify that feeding all the data at once (with Update())
+// gives the same result as feeding data one byte at a time (with Rotate(),
+// Rollin(), and Rollout()).
+func TestRollsumConsistency(t *testing.T) {
+	a := assert.New(t)
+	data1 := []byte{ /* */ 66, 1, 111, 54, 171, 12, 255, 199, 1, 2, 7, 12, 54, 43, 101}
+	data2 := []byte{4, 22, 66, 1, 111, 54, 171, 12, 255, 199, 1, 2, 7, 12, 54 /*    */}
+
+	rk1 := Rollsum{}
+	rk1.Update(data1)
+
+	rk2 := Rollsum{}
+	for _, v := range data2 {
+		rk2.Rollin(v)
+	}
+	rk2.Rotate(4, 43)
+	rk2.Rollout(22)
+	rk2.Rollin(101)
+
+	a.Equal(rk1.Digest(), rk2.Digest())
+}
+
+// This used to trigger a bug in Rotate(), caused by the use of subtraction with
+// bytes, which should be using proper signed integers instead.
+func TestRollsumRotateByteSubtractionBug(t *testing.T) {
+	a := assert.New(t)
+
+	rk1 := Rollsum{}
+	rk1.Rollin(1) // { 1 }
+	a.Equal(uint32(0x00200020), rk1.Digest())
+
+	rk2 := Rollsum{}
+	rk2.Rollin(2)    // { 2 }
+	rk2.Rotate(2, 1) // { 1 }
+
+	a.Equal(rk1.Digest(), rk2.Digest())
+}


### PR DESCRIPTION
Rollsum.Rotate() was previously doing subtraction on values of type
byte, which in Go always result in a byte (and therefore unsigned)
value. That subtraction was supposed to be signed tough.

This also add unit tests to Rollsum, including a simple one that used to
trigger the bug described above. All "expected" values used in these
unit tests were generated using the original librsync.

Signed-off-by: Leandro Motta Barros <leandro@balena.io>