### PR TITLE
Don't ignore last block when generating the signature

### DIFF
--- a/helpers_test.go
+++ b/helpers_test.go
@@ -6,6 +6,40 @@ import (
 	"strings"
 )
 
+var allTestCases = []string{
+	"000-blake2-11-23",
+	"000-blake2-512-32",
+	"000-md4-256-7",
+	"001-blake2-512-32",
+	"001-blake2-776-31",
+	"001-md4-777-15",
+	"002-blake2-512-32",
+	"002-blake2-431-19",
+	"002-md4-128-16",
+	"003-blake2-512-32",
+	"003-blake2-1024-13",
+	"003-md4-1024-13",
+	"004-blake2-1024-28",
+	"004-blake2-2222-31",
+	"004-blake2-512-32",
+	"005-blake2-512-32",
+	"005-blake2-1000-18",
+	"005-md4-999-14",
+	"006-blake2-2-32",
+	"007-blake2-5-32",
+	"007-blake2-4-32",
+	"007-blake2-3-32",
+	"008-blake2-222-30",
+	"008-blake2-512-32",
+	"008-md4-111-11",
+	"009-blake2-2048-26",
+	"009-blake2-512-32",
+	"009-md4-2033-15",
+	"010-blake2-512-32",
+	"010-blake2-7-6",
+	"010-md4-4096-8",
+}
+
 func argsFromTestName(name string) (file string, magic MagicNumber, blockLen, strongLen uint32, err error) {
 	segs := strings.Split(name, "-")
 	if len(segs) != 4 {

--- a/signature.go
+++ b/signature.go
@@ -75,7 +75,7 @@ func Signature(input io.Reader, output io.Writer, blockLen, strongLen uint32, si
 
 	for {
 		n, err := input.Read(block)
-		if err == io.ErrUnexpectedEOF || err == io.EOF {
+		if err == io.EOF {
 			break
 		} else if err != nil {
 			return nil, err

--- a/signature.go
+++ b/signature.go
@@ -74,7 +74,7 @@ func Signature(input io.Reader, output io.Writer, blockLen, strongLen uint32, si
 	ret.blockLen = blockLen
 
 	for {
-		n, err := io.ReadFull(input, block)
+		n, err := input.Read(block)
 		if err == io.ErrUnexpectedEOF || err == io.EOF {
 			break
 		} else if err != nil {

--- a/signature_test.go
+++ b/signature_test.go
@@ -35,45 +35,11 @@ func signature(t errorI, src io.Reader) *SignatureType {
 	return s
 }
 
-var signatureTestCases = []string{
-	// "000-blake2-11-23",
-	// "000-blake2-512-32",
-	// "000-md4-256-7",
-	// "001-blake2-512-32",
-	// "001-blake2-776-31",
-	// "001-md4-777-15",
-	// "002-blake2-512-32",
-	// "002-blake2-431-19",
-	// "002-md4-128-16",
-	"003-blake2-512-32",
-	"003-blake2-1024-13",
-	"003-md4-1024-13",
-	// "004-blake2-1024-28",
-	// "004-blake2-2222-31",
-	// "004-blake2-512-32",
-	// "005-blake2-512-32",
-	// "005-blake2-1000-18",
-	// "005-md4-999-14",
-	// "006-blake2-2-32",
-	"007-blake2-5-32",
-	// "007-blake2-4-32",
-	// "007-blake2-3-32",
-	// "008-blake2-222-30",
-	// "008-blake2-512-32",
-	// "008-md4-111-11",
-	"009-blake2-2048-26",
-	"009-blake2-512-32",
-	"009-md4-2033-15",
-	"010-blake2-512-32",
-	"010-blake2-7-6",
-	"010-md4-4096-8",
-}
-
 func TestSignature(t *testing.T) {
 	r := require.New(t)
 	a := assert.New(t)
 
-	for _, tt := range signatureTestCases {
+	for _, tt := range allTestCases {
 		t.Run(tt, func(t *testing.T) {
 			file, magic, blockLen, strongLen, err := argsFromTestName(tt)
 			r.NoError(err)


### PR DESCRIPTION
When generating signatures, if the last remaining block is shorter than `blockLen` `io.ReadFull` will return `io.ErrUnexpectedEOF` and the block will not be processed (signature will be one block too short).

This PR includes the cherry-picked commit originally contributed in https://github.com/balena-os/librsync-go/pull/3 and also a few improvements (namely, enable test cases that will now pass and avoid checking for `io.ErrUnexpectedEOF` which will not happen anymore after the first commit).
