### PR TITLE
Avoid unbounded memory allocations when creating deltas

### DIFF
--- a/delta.go
+++ b/delta.go
@@ -18,7 +18,7 @@ func Delta(sig *SignatureType, i io.Reader, output io.Writer) error {
 	}
 
 	prevByte := byte(0)
-	m := match{output: output}
+	m := newMatch(output)
 
 	weakSum := NewRollsum()
 	block, _ := circbuf.NewBuffer(int64(sig.blockLen))

--- a/match.go
+++ b/match.go
@@ -13,6 +13,11 @@ const (
 	MATCH_KIND_COPY
 )
 
+// Size of the output buffer in bytes. We'll flush the match once it gets this
+// large. As consequence, this is the maximum size of a LITERAL command we'll
+// generate on our deltas.
+const OUTPUT_BUFFER_SIZE = 16 * 1024 * 1024
+
 type match struct {
 	kind   matchKind
 	pos    uint64
@@ -31,6 +36,13 @@ func intSize(d uint64) uint8 {
 		return 4
 	default:
 		return 8
+	}
+}
+
+func newMatch(output io.Writer) match {
+	return match{
+		output: output,
+		lit:    make([]byte, 0, OUTPUT_BUFFER_SIZE),
 	}
 }
 
@@ -112,8 +124,11 @@ func (m *match) flush() error {
 		if err != nil {
 			return err
 		}
-		m.output.Write(m.lit)
-		m.lit = []byte{}
+		_, err = m.output.Write(m.lit)
+		if err != nil {
+			return err
+		}
+		m.lit = m.lit[:0] // reuse the same buffer
 	}
 	m.pos = 0
 	m.len = 0
@@ -134,8 +149,13 @@ func (m *match) add(kind matchKind, pos, len uint64) error {
 	case MATCH_KIND_LITERAL:
 		m.lit = append(m.lit, byte(pos))
 		m.len += 1
+		if m.len >= OUTPUT_BUFFER_SIZE {
+			err := m.flush()
+			if err != nil {
+				return err
+			}
+		}
 	case MATCH_KIND_COPY:
-		m.lit = []byte{}
 		if m.pos+m.len != pos {
 			err := m.flush()
 			if err != nil {

--- a/performace_measurements/create-pm-data.sh
+++ b/performace_measurements/create-pm-data.sh
@@ -29,13 +29,13 @@ function generateRandomFiles() {
     dd if=/dev/urandom of=post.tmp bs=1K count=$(($1/10))
     dd if=/dev/urandom of=alt.tmp bs=1K count=$(($1/10))
 
-    cat pre.tmp mid.tmp post.tmp > $1-abc.data
-    cat mid.tmp post.tmp > $1-bc.data
-    cat mid.tmp > $1-b.data
-    cat pre.tmp mid.tmp post.tmp alt.tmp > $1-abcx.data
-    cat pre.tmp mid.tmp alt.tmp > $1-abx.data
-    cat alt.tmp mid.tmp post.tmp > $1-xbc.data
-    cat pre.tmp alt.tmp post.tmp > $1-axc.data
+    cat pre.tmp mid.tmp post.tmp > ${1}000-abc.data
+    cat mid.tmp post.tmp > ${1}000-bc.data
+    cat mid.tmp > ${1}000-b.data
+    cat pre.tmp mid.tmp post.tmp alt.tmp > ${1}000-abcx.data
+    cat pre.tmp mid.tmp alt.tmp > ${1}000-abx.data
+    cat alt.tmp mid.tmp post.tmp > ${1}000-xbc.data
+    cat pre.tmp alt.tmp post.tmp > ${1}000-axc.data
 
     rm -f pre.tmp mid.tmp post.tmp alt.tmp
 }


### PR DESCRIPTION
Previously, we could allocate unbounded amounts of memory when generating deltas. See details on the individual commits, but in summary, we were allocating enough memory to store the longest sequence of bytes in the target file that did not have a match on the basis file. In other words, if the new file had a sequence of 10GB of data without match on the basis file, we'd allocate a 10GB buffer. Here we allocate a fixed 16MB buffer.

We also make sure we keep reusing this buffer instead of reallocating buffers as before, thus avoiding unnecessary work and generating less garbage for the garbage collector (this gave us a 2% performance boost according to my measurements).

This PR also includes some minor improvements to the scripts we use to benchmark the library.

For more info and test results: https://gist.github.com/lmbarros/c094e3bb08e8ffbc7ce23955c7a56411#the-lmblimit-memory-usage-branch (This links to the relevant section of a work-in-progress analysis of a larger set of delta improvements I am hoping to merge in the upcoming weeks).