### PR TITLE
Close the delta file after running the delta command

### DIFF
--- a/cmd/rdiff/delta.go
+++ b/cmd/rdiff/delta.go
@@ -40,7 +40,7 @@ func CommandDelta(c *cli.Context) {
 	if err != nil {
 		logrus.Fatal(err)
 	}
-	defer newfile.Close()
+	defer delta.Close()
 
 	err = librsync.Delta(signature, newfile, delta)
 	if err != nil {


### PR DESCRIPTION
We were previously closing the new file twice by mistake, while leaving the delta file unclosed.

Fixes #22 