### PR TITLE
fix: reading of strongSum in ReadSignature()

### DIFF
--- a/signature.go
+++ b/signature.go
@@ -131,12 +131,9 @@ func ReadSignature(r io.Reader) (*SignatureType, error) {
 		}
 
 		strongSum := make([]byte, strongLen)
-		n, err := r.Read(strongSum)
+		_, err := io.ReadAtLeast(r, strongSum, int(strongLen))
 		if err != nil {
 			return nil, err
-		}
-		if n != int(strongLen) {
-			return nil, fmt.Errorf("got only %d/%d bytes of the strong hash", n, strongLen)
 		}
 
 		weak2block[weakSum] = len(strongSigs)

--- a/signature.go
+++ b/signature.go
@@ -131,7 +131,7 @@ func ReadSignature(r io.Reader) (*SignatureType, error) {
 		}
 
 		strongSum := make([]byte, strongLen)
-		_, err := io.ReadAtLeast(r, strongSum, int(strongLen))
+		_, err := io.ReadFull(r, strongSum)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
* Read `strongSum` using `io.ReadAtLeast()`, important when not reading from file (e.g. pipe/network).

Change-Type: patch