### PR TITLE
fix: performance scripts use the wrong interpreter

### DIFF
--- a/performace_measurements/create-pm-data.sh
+++ b/performace_measurements/create-pm-data.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #
 # Generates files to use as input for `run-pm.sh`.

--- a/performace_measurements/run-pm.sh
+++ b/performace_measurements/run-pm.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Measures CPU time, memory usage and resulting file sizes for the various
 # operations supported by librsync-go (signature, delta, patch) when invoked


### PR DESCRIPTION
Performance scripts use the `#!/bin/sh` shebang but use function syntax that is not supported, use bash instead.

Change-type: minor