### PR TITLE
Signature input size aware

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -8,13 +8,13 @@ import (
 	"time"
 )
 
-// Benchmarks generting a signature for a file totalBytes long.
+// Benchmarks generating a signature for a file totalBytes long.
 func benchmarkSignature(b *testing.B, totalBytes int64) {
 	b.SetBytes(totalBytes)
 
 	for i := 0; i < b.N; i++ {
 		src := io.LimitReader(rand.New(rand.NewSource(time.Now().UnixNano())), totalBytes)
-		signature(b, src)
+		signature(b, src, totalBytes)
 	}
 }
 
@@ -32,7 +32,7 @@ func benchmarkDeltaChangeTail(b *testing.B, totalBytes int64) {
 	oldBytes := totalBytes - newBytes
 	oldSeed := time.Now().UnixNano()
 	oldData := io.LimitReader(rand.New(rand.NewSource(oldSeed)), totalBytes)
-	s := signature(b, oldData)
+	s := signature(b, oldData, totalBytes)
 
 	b.SetBytes(totalBytes)
 	b.ResetTimer()
@@ -72,7 +72,7 @@ func benchmarkDeltaAppend(b *testing.B, totalBytes int64) {
 	newBytes := totalBytes / 10
 	oldSeed := time.Now().UnixNano()
 	oldData := io.LimitReader(rand.New(rand.NewSource(oldSeed)), totalBytes)
-	s := signature(b, oldData)
+	s := signature(b, oldData, totalBytes)
 
 	b.SetBytes(totalBytes)
 	b.ResetTimer()
@@ -107,7 +107,7 @@ func benchmarkDeltaPrepend(b *testing.B, totalBytes int64) {
 	newBytes := totalBytes / 10
 	oldSeed := time.Now().UnixNano()
 	oldData := io.LimitReader(rand.New(rand.NewSource(oldSeed)), totalBytes)
-	s := signature(b, oldData)
+	s := signature(b, oldData, totalBytes)
 
 	b.SetBytes(totalBytes)
 	b.ResetTimer()
@@ -146,7 +146,7 @@ func benchmarkDeltaInpend(b *testing.B, totalBytes int64) {
 	firstBytes := totalBytes / 3
 	lastBytes := totalBytes - firstBytes
 
-	s := signature(b, oldData)
+	s := signature(b, oldData, totalBytes)
 
 	b.SetBytes(totalBytes)
 	b.ResetTimer()
@@ -188,7 +188,7 @@ func benchmarkDeltaCutTail(b *testing.B, totalBytes int64) {
 	newBytes := totalBytes - totalBytes/10
 	oldSeed := time.Now().UnixNano()
 	oldData := io.LimitReader(rand.New(rand.NewSource(oldSeed)), totalBytes)
-	s := signature(b, oldData)
+	s := signature(b, oldData, totalBytes)
 
 	b.SetBytes(totalBytes)
 	b.ResetTimer()
@@ -220,7 +220,7 @@ func BenchmarkDeltaCutTail1MB(b *testing.B) {
 func benchmarkDeltaCutHead(b *testing.B, totalBytes int64) {
 	oldSeed := time.Now().UnixNano()
 	oldData := io.LimitReader(rand.New(rand.NewSource(oldSeed)), totalBytes)
-	s := signature(b, oldData)
+	s := signature(b, oldData, totalBytes)
 
 	b.SetBytes(totalBytes)
 	b.ResetTimer()

--- a/cmd/rdiff/main.go
+++ b/cmd/rdiff/main.go
@@ -24,8 +24,8 @@ func main() {
 			Flags: []cli.Flag{
 				cli.UintFlag{
 					Name:  "block-size, b",
-					Value: 2048,
-					Usage: "Signature block size",
+					Value: 0,
+					Usage: "Signature block size (0 for auto)",
 				},
 				cli.UintFlag{
 					Name:  "sum-size, S",

--- a/cmd/rdiff/signature.go
+++ b/cmd/rdiff/signature.go
@@ -35,6 +35,12 @@ func CommandSignature(c *cli.Context) {
 		logrus.Fatalf("Invalid hash type: %v", c.String("hash"))
 	}
 
+	stats, err := os.Stat(c.Args().Get(0))
+	if err != nil {
+		logrus.Fatal(err)
+	}
+	inputSize := stats.Size()
+
 	basis, err := os.Open(c.Args().Get(0))
 	if err != nil {
 		logrus.Fatal(err)
@@ -48,7 +54,7 @@ func CommandSignature(c *cli.Context) {
 	defer signature.Close()
 	output := bufio.NewWriter(signature)
 
-	_, err = librsync.Signature(basis, output, uint32(c.Uint("block-size")), uint32(c.Uint("sum-size")), sigType)
+	_, err = librsync.Signature(basis, output, uint32(c.Uint("block-size")), uint32(c.Uint("sum-size")), sigType, inputSize)
 	if err != nil {
 		logrus.Fatal(err)
 	}

--- a/delta_test.go
+++ b/delta_test.go
@@ -25,7 +25,7 @@ func TestDeltaSmokeTest(t *testing.T) {
 		io.LimitReader(rand.New(rand.NewSource(time.Now().UnixNano())), totalBytes),
 		&srcBuf)
 
-	s := signature(t, src)
+	s := signature(t, src, totalBytes)
 
 	var buf bytes.Buffer
 

--- a/performace_measurements/.gitignore
+++ b/performace_measurements/.gitignore
@@ -1,0 +1,4 @@
+venv
+*.data
+*.png
+*.csv

--- a/performace_measurements/README.md
+++ b/performace_measurements/README.md
@@ -1,0 +1,24 @@
+# generate test data
+
+```bash
+bash ./create-pm-data.sh
+```
+
+# perform measurements
+
+```bash
+bash ./run-pm.sh
+```
+
+# generate graphs
+
+Install dependencies:
+```bash
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+```bash
+./visualize.py sigTime old.csv new.csv
+```

--- a/performace_measurements/requirements.txt
+++ b/performace_measurements/requirements.txt
@@ -1,0 +1,12 @@
+contourpy==1.3.3
+cycler==0.12.1
+fonttools==4.62.0
+kiwisolver==1.5.0
+matplotlib==3.10.8
+numpy==2.4.3
+packaging==26.0
+pandas==3.0.1
+pillow==12.1.1
+pyparsing==3.3.2
+python-dateutil==2.9.0.post0
+six==1.17.0

--- a/performace_measurements/visualize.py
+++ b/performace_measurements/visualize.py
@@ -1,0 +1,134 @@
+#!/bin/env python3
+
+import sys
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import matplotlib.ticker as ticker
+import pandas as pd
+
+
+def timeFormatter(t, pos):
+    if t < 10e-6:
+        return "%dns" % (t * 1e9)
+    elif t < 10e-3:
+        return "%dμs" % (t * 1e6)
+    elif t < 1:
+        return "%dms" % (t * 1e3)
+    elif t < 1e3:
+        return "%.2fs" % (t)
+    else:
+        return "%.2es" % (t)
+
+
+def bytesFormatter(n, pos):
+    if n < 1e3:
+        return "%db" % (n)
+    elif n < 1e6:
+        return "%.1fkb" % (n / 1e3)
+    elif n < 1e9:
+        return "%.1fMb" % (n / 1e6)
+    elif n < 1e12:
+        return "%.1fGb" % (n / 1e9)
+    else:
+        return "%.1fTb" % (n / 1e12)
+
+
+def cmp(dfs, col):
+    unit = COLS_2_UNIT[col]
+    fmt = COLS_2_FMT[col]
+
+    for (name, df) in dfs.items():
+        mean = df.groupby(by="fileSize")[[col]].mean()
+        plt.scatter(mean.index, mean.values, label=name)
+
+        for (idx, row) in mean.iterrows():
+            t = row.values[0]
+            plt.gca().annotate(fmt(t), (idx, t), xytext=(
+                10, 0), textcoords='offset points')
+
+    plt.title("%s" % col)
+    plt.legend()
+
+    plt.xlabel("fileSize")
+    plt.xscale("log")
+    plt.gca().xaxis.set_major_formatter(ticker.FuncFormatter(bytesFormatter))
+
+    plt.ylabel(unit)
+    plt.yscale("log")
+    plt.gca().yaxis.set_major_formatter(fmt)
+
+    plt.show()
+
+
+COLS = [
+    "sigSize",
+    "sigTime",
+    "sigMem",
+    "deltaSize",
+    "deltaTime",
+    "deltaMem",
+    "patchTime",
+    "patchMem",
+]
+
+COLS_2_UNIT = {
+    "sigSize": "size (bytes)",
+    "sigTime": "mean time",
+    "sigMem": "size (bytes)",
+    "deltaSize": "size (bytes)",
+    "deltaTime": "mean time",
+    "deltaMem": "size (bytes)",
+    "patchTime": "mean time",
+    "patchMem": "size (bytes)",
+}
+
+COLS_2_FMT = {
+    "sigSize": ticker.FuncFormatter(bytesFormatter),
+    "sigTime": ticker.FuncFormatter(timeFormatter),
+    "sigMem": ticker.FuncFormatter(bytesFormatter),
+    "deltaSize": ticker.FuncFormatter(bytesFormatter),
+    "deltaTime": ticker.FuncFormatter(timeFormatter),
+    "deltaMem": ticker.FuncFormatter(bytesFormatter),
+    "patchTime": ticker.FuncFormatter(timeFormatter),
+    "patchMem": ticker.FuncFormatter(bytesFormatter),
+}
+
+
+def printUsage():
+    binName = sys.argv[0]
+    print("""Compare a given stat from the provided csv files and displays a plot.
+
+Usage: %s STAT CSV_FILE...
+
+Arguments:
+    STAT
+        can be one of %s
+
+    CSV_FILE...
+        csv files containing the given stat""" % (binName, ", ".join(COLS)))
+
+
+def main(argv):
+    if len(argv) < 2:
+        printUsage()
+        exit(1)
+
+    col = argv[0]
+    if col not in COLS:
+        print("column must be one off: %s" % ", ".join(COLS))
+        printUsage()
+        exit(1)
+
+    dfs = {}
+    for arg in argv[1:]:
+        df = pd.read_csv(arg)
+
+        name = Path(arg).stem
+        dfs[name] = df
+
+    cmp(dfs, col)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/signature.go
+++ b/signature.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"math"
 	"os"
 
 	"golang.org/x/crypto/blake2b"
@@ -11,8 +12,11 @@ import (
 )
 
 const (
-	BLAKE2_SUM_LENGTH = 32
-	MD4_SUM_LENGTH    = 16
+	BLAKE2_SUM_LENGTH            = 32
+	MD4_SUM_LENGTH               = 16
+	INPUT_SIZE_FOR_MIN_BLOCK_LEN = 65536
+	DEFAULT_BLOCK_LEN            = 2048
+	MIN_BLOCK_LEN                = 256
 )
 
 type SignatureType struct {
@@ -21,6 +25,25 @@ type SignatureType struct {
 	strongLen  uint32
 	strongSigs [][]byte
 	weak2block map[uint32]int
+}
+
+// Based on the original librsync.
+// https://github.com/librsync/librsync/blob/271744de428c0177e993f95c045d70b8cf2558f2/src/sumset.c#L141
+// Attempts to give a block len that is a reasonable compromise between signature size, delta size,
+// and performance.
+func recommendBlockLen(size int64) uint32 {
+	if size <= 0 {
+		// don't know what the input size is, use a balanced block len
+		return DEFAULT_BLOCK_LEN
+	} else if size <= INPUT_SIZE_FOR_MIN_BLOCK_LEN {
+		return MIN_BLOCK_LEN
+	} else {
+		sizeSqrt := math.Floor(math.Sqrt(float64(size)))
+		// round up the result to be a multiple of 128 to match blake2b internal buffer
+		size128 := uint32(sizeSqrt) & ^uint32(127)
+
+		return size128
+	}
 }
 
 func CalcStrongSum(data []byte, sigType MagicNumber, strongLen uint32) ([]byte, error) {
@@ -36,7 +59,7 @@ func CalcStrongSum(data []byte, sigType MagicNumber, strongLen uint32) ([]byte, 
 	return nil, fmt.Errorf("Invalid sigType %#x", sigType)
 }
 
-func Signature(input io.Reader, output io.Writer, blockLen, strongLen uint32, sigType MagicNumber) (*SignatureType, error) {
+func Signature(input io.Reader, output io.Writer, blockLen, strongLen uint32, sigType MagicNumber, inputSize int64) (*SignatureType, error) {
 	var maxStrongLen uint32
 
 	switch sigType {
@@ -52,6 +75,10 @@ func Signature(input io.Reader, output io.Writer, blockLen, strongLen uint32, si
 		return nil, fmt.Errorf("invalid strongLen %d for sigType %#x", strongLen, sigType)
 	}
 
+	if blockLen == 0 {
+		blockLen = recommendBlockLen(inputSize)
+	}
+
 	err := binary.Write(output, binary.BigEndian, sigType)
 	if err != nil {
 		return nil, err
@@ -65,10 +92,19 @@ func Signature(input io.Reader, output io.Writer, blockLen, strongLen uint32, si
 		return nil, err
 	}
 
+	nbBlocks := int64(0)
+	if inputSize > 0 {
+		nbBlocks = inputSize / int64(blockLen)
+		if inputSize%int64(blockLen) != 0 {
+			nbBlocks += 1
+		}
+	}
+
 	block := make([]byte, blockLen)
 
 	var ret SignatureType
-	ret.weak2block = make(map[uint32]int)
+	ret.weak2block = make(map[uint32]int, nbBlocks)
+	ret.strongSigs = make([][]byte, 0, nbBlocks)
 	ret.sigType = sigType
 	ret.strongLen = strongLen
 	ret.blockLen = blockLen

--- a/signature_test.go
+++ b/signature_test.go
@@ -16,7 +16,7 @@ type errorI interface {
 	Error(args ...interface{})
 }
 
-func signature(t errorI, src io.Reader) *SignatureType {
+func signature(t errorI, src io.Reader, inputSize int64) *SignatureType {
 	var (
 		magic            = BLAKE2_SIG_MAGIC
 		blockLen  uint32 = 512
@@ -27,7 +27,7 @@ func signature(t errorI, src io.Reader) *SignatureType {
 	s, err := Signature(
 		bufio.NewReaderSize(src, bufSize),
 		ioutil.Discard,
-		blockLen, strongLen, magic)
+		blockLen, strongLen, magic, inputSize)
 	if err != nil {
 		t.Error(err)
 	}
@@ -49,7 +49,7 @@ func TestSignature(t *testing.T) {
 			input := bytes.NewReader(inputData)
 
 			output := &bytes.Buffer{}
-			gotSig, err := Signature(input, output, blockLen, strongLen, magic)
+			gotSig, err := Signature(input, output, blockLen, strongLen, magic, int64(len(inputData)))
 			r.NoError(err)
 
 			wantSig, err := ReadSignatureFile("testdata/" + tt + ".signature")
@@ -64,5 +64,24 @@ func TestSignature(t *testing.T) {
 			r.NoError(err)
 			a.Equal(expectedData, outputData)
 		})
+	}
+}
+
+func TestRecommendBlockLen(t *testing.T) {
+	a := assert.New(t)
+
+	tt := []struct {
+		InputSize int64
+		BlockLen  uint32
+	}{
+		{0, DEFAULT_BLOCK_LEN},
+		{1, MIN_BLOCK_LEN},
+		{1000000, 896},
+	}
+
+	for _, test := range tt {
+		blockLen := recommendBlockLen(test.InputSize)
+
+		a.Equal(test.BlockLen, blockLen)
 	}
 }


### PR DESCRIPTION
If signature generation is aware of input size it allows it to choose an approriate block len, I adapted the code from the original librsync to do exactly this.

This introduces 2 breaking changes:
- The rdiff cli default value for `--block-size` is now 0, which means that the block len will be chosen automatically, this is consistent with the way the original rdiff works
- The function `Signature(...)` has a new argument

TLDR: This should significantly reduce memory usage and computation time for large files. File sizes (bandwidth) will increase for smaller files but decrease for larger files.

# Measurements

New rdiff version, block-size=0 (block len will be chosen automatically).
[auto.csv](https://github.com/user-attachments/files/25855767/auto.csv)

New rdiff version, block-size=2048 (this matches the old behavior).
[2048.csv](https://github.com/user-attachments/files/25855770/2048.csv)

Key takeways:
- signature size increases for smaller files (<1MB) but decreases for medium to large files (>1MB)
- delta size doesn't change
- delta computation time decreases significantly for large files (>100MB)
- signature and patch computation time don't change
- signature and delta memory usage decrease significantly for large files (>100MB)
- patch memory usage doesn't change

# File sizes

`./visualize.py sigSize auto.csv 2048.csv`
<img width="640" height="480" alt="sigSize" src="https://github.com/user-attachments/assets/d4bf86eb-a227-423b-aee3-0b8768cbda76" />

`./visualize.py deltaSize auto.csv 2048.csv`
<img width="640" height="480" alt="deltaSize" src="https://github.com/user-attachments/assets/56358ecd-b54c-4b3d-b49f-b0904019bacb" />

# Computation time

`./visualize.py sigTime auto.csv 2048.csv`
<img width="640" height="480" alt="sigTime" src="https://github.com/user-attachments/assets/7b2f4697-acd8-4ff5-94fb-5d745f875836" />

`./visualize.py deltaTime auto.csv 2048.csv`
<img width="640" height="480" alt="deltaTime" src="https://github.com/user-attachments/assets/d447eb9e-1b5f-430d-a518-90144efe427a" />

`./visualize.py patchTime auto.csv 2048.csv`
<img width="640" height="480" alt="patchTime" src="https://github.com/user-attachments/assets/6a6c0ee7-1071-448e-9527-dc7152d48a8a" />

# Memory usage

`./visualize.py sigMem auto.csv 2048.csv`
<img width="640" height="480" alt="sigMem" src="https://github.com/user-attachments/assets/7be5fe14-5917-434d-9042-5e77e203990c" />

`./visualize.py deltaMem auto.csv 2048.csv`
<img width="640" height="480" alt="deltaMem" src="https://github.com/user-attachments/assets/6477466a-38b6-4b85-95dc-93f0400990e6" />

That one is a mess, but the point is nothing changed.
`./visualize.py patchMem auto.csv 2048.csv`
<img width="640" height="480" alt="patchMem" src="https://github.com/user-attachments/assets/b5a1c43f-2a83-4f25-b9a8-c223f6e93f78" />
